### PR TITLE
[FIX] undo check for TIC

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -171,8 +171,6 @@ class Reader(object):
                 if build_index_from_scratch:
                     self._build_index_from_scratch(self.seeker)
                 # print('Could not find indexList. Falling back to non seekable.', file = sys.stderr)
-            elif self.info['offsets']['TIC'] == None:
-                self.info['seekable'] = False
             elif self.info['offsets']['TIC']  > os.path.getsize(self.info['filename']):
                 self.info['seekable'] = False
                 #print('mzML file was truncated, but offsets were not recalculated. Falling back to non seekable.', file = sys.stderr)


### PR DESCRIPTION
TIC does not need to be present in a valid mzML, requiring it to be
present in all cases causes many valid mzML files to not be parsed at
all.

undo commit ef404d671b0afc6dc03be4d03715fd068de54f96
