### PR TITLE
Feature: add chromatogram count

### DIFF
--- a/example_scripts/get_example_file.py
+++ b/example_scripts/get_example_file.py
@@ -12,25 +12,69 @@ from __future__ import print_function
 import sys
 import os.path
 import hashlib
-                                                                                                                                                                                        
-SHA256_DICT = {'deconvolution.mzML.gz':                 ('19399e4f87d8937cf7be32bab7fd8889700e119cbc2ede215270cbfc9913b394', 'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/'),
-               'dta_example.mzML':                      ('2cd7207d5106ee5fb3ab7867961a6c1ad02f0ef72da19532e7ebb41c8d010b1a', 'http://dev.thep.lu.se/fp6-prodac/export/80/trunk/mzML/'),
-               'neutral_loss_example_1.1.0.mzML':       ('5911fa5d91a435aedd7be5a2ea09272f437d44f350948179a96146705a177a16', 'http://dev.thep.lu.se/fp6-prodac/export/80/trunk/mzML/scans/'),
-               'precursor_spectrum_example_1.1.0.mzML': ('783187ec7eb2ee2713aecd9f6032508caad3439afa0b4a20232480b33472c17b', 'http://dev.thep.lu.se/fp6-prodac/export/80/trunk/mzML/scans/'),
-               'profile-mass-spectrum.mzml':            ('2e952de2a25db421f3e30d8c659acc6c3f5e862e4d0fd32ec24c7c606c9a62fd', 'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/'),
-               'small-1.0.0.mzml':                      ('9e15d6d2eba26932e4d5c61f92df7771da0bbb8589b7237d05bd915017dbf82f', 'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/'),
-               'BSA1.mzML':                             ('d4bde93c77ec9e948cc62f4c022b8d54591073fd1170e264b69a79dc8d259830', 'http://open-ms.svn.sourceforge.net/viewvc/open-ms/OpenMS/share/OpenMS/examples/BSA/'),
-               'proteomeDiscoverer.mzML.gz':            ('7fdd45bfcb6d82b2a75abd63fdc0d8cc1f14c1bd717ba2f3d4eec87ec201f3be', 'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/'),
-               '32-bit.mzML.gz':                        ('199d2611c9894f2a07fb734fbe4db2226cd2a43e806d4e9662b66b979f7df264', 'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/'),
-               '32-bit-compressed.mzML.gz':             ('30fdde9ebf3bb145a60ea589f466cb0db8b3b2c451646156db3e56ffe1bf0e59', 'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/'),
-               '64-bit.mzML.gz':                        ('0d56a2295096e7499a8a90509661d22d4a6a097ad58f3c03310804c9698113aa', 'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/'),
-               'small.pwiz.1.1.mzML':                   ('87ddde776c9933857edb22f404116f23e85ca8bddadc84d10308eb8853a58768', 'http://proteowizard.sourceforge.net/example_data/'),
-               'MRM_example_1.1.0.mzML':                ('8140d77921be6fe49e73d71536b211ad39ae48f0272d4a465da2dd202185bdd9', 'http://dev.thep.lu.se/fp6-prodac/export/80/trunk/mzML/scans/'),
-               'emptyScan.mzML.gz':                     ('4d82ea02c1f938e8fbe97b907371aad0eceee074bbee37f7513374a1bb7c3f3b', 'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/')
-                }
+
+SHA256_DICT = {
+    'deconvolution.mzML.gz': (
+        '19399e4f87d8937cf7be32bab7fd8889700e119cbc2ede215270cbfc9913b394',
+        'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/',
+    ),
+    'dta_example.mzML': (
+        '2cd7207d5106ee5fb3ab7867961a6c1ad02f0ef72da19532e7ebb41c8d010b1a',
+        'http://dev.thep.lu.se/fp6-prodac/export/80/trunk/mzML/',
+    ),
+    'neutral_loss_example_1.1.0.mzML': (
+        '5911fa5d91a435aedd7be5a2ea09272f437d44f350948179a96146705a177a16',
+        'http://dev.thep.lu.se/fp6-prodac/export/80/trunk/mzML/scans/',
+    ),
+    'precursor_spectrum_example_1.1.0.mzML': (
+        '783187ec7eb2ee2713aecd9f6032508caad3439afa0b4a20232480b33472c17b',
+        'http://dev.thep.lu.se/fp6-prodac/export/80/trunk/mzML/scans/',
+    ),
+    'profile-mass-spectrum.mzml': (
+        '2e952de2a25db421f3e30d8c659acc6c3f5e862e4d0fd32ec24c7c606c9a62fd',
+        'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/',
+    ),
+    'small-1.0.0.mzml': (
+        '9e15d6d2eba26932e4d5c61f92df7771da0bbb8589b7237d05bd915017dbf82f',
+        'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/',
+    ),
+    'BSA1.mzML': (
+        'd4bde93c77ec9e948cc62f4c022b8d54591073fd1170e264b69a79dc8d259830',
+        'http://open-ms.svn.sourceforge.net/viewvc/open-ms/OpenMS/share/OpenMS/examples/BSA/',
+    ),
+    'proteomeDiscoverer.mzML.gz': (
+        '7fdd45bfcb6d82b2a75abd63fdc0d8cc1f14c1bd717ba2f3d4eec87ec201f3be',
+        'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/',
+    ),
+    '32-bit.mzML.gz': (
+        '199d2611c9894f2a07fb734fbe4db2226cd2a43e806d4e9662b66b979f7df264',
+        'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/',
+    ),
+    '32-bit-compressed.mzML.gz': (
+        '30fdde9ebf3bb145a60ea589f466cb0db8b3b2c451646156db3e56ffe1bf0e59',
+        'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/',
+    ),
+    '64-bit.mzML.gz': (
+        '0d56a2295096e7499a8a90509661d22d4a6a097ad58f3c03310804c9698113aa',
+        'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/',
+    ),
+    'small.pwiz.1.1.mzML': (
+        '87ddde776c9933857edb22f404116f23e85ca8bddadc84d10308eb8853a58768',
+        'http://proteowizard.sourceforge.net/example_data/',
+    ),
+    'MRM_example_1.1.0.mzML': (
+        '8140d77921be6fe49e73d71536b211ad39ae48f0272d4a465da2dd202185bdd9',
+        'http://dev.thep.lu.se/fp6-prodac/export/80/trunk/mzML/scans/',
+    ),
+    'emptyScan.mzML.gz': (
+        '4d82ea02c1f938e8fbe97b907371aad0eceee074bbee37f7513374a1bb7c3f3b',
+        'http://www.uni-muenster.de/hippler/pymzml/example_mzML_files/',
+    )
+}
 
 EXAMPLE_DIR = os.path.join(os.path.dirname(__file__), 'mzML_example_files')
-OUTPUT_DIR  = os.path.join(os.path.dirname(__file__), 'output')
+OUTPUT_DIR = os.path.join(os.path.dirname(__file__), 'output')
+
 try:
     os.makedirs(EXAMPLE_DIR)
 except OSError:
@@ -50,15 +94,15 @@ def open_example(filename):
     try:
         SHA256_DICT[filename]
     except KeyError:
-        print('File "{0}" not available.'.format(filename), file = sys.stderr)
+        print('File "{0}" not available.'.format(filename), file=sys.stderr)
         exit(1)
-    
+
     filename_with_path = os.path.join(EXAMPLE_DIR, filename)
     # check file presence
     checked_file = check_file(filename_with_path, filename)
     if checked_file:
         return filename_with_path
-    
+
     # file is not present or corrupt
     server_url = SHA256_DICT[filename][1]
     url = server_url + filename
@@ -68,10 +112,11 @@ def open_example(filename):
             return filename_with_path
         else:
             os.remove(filename_with_path)
-            print("Downloaded file is corrupt. Please try again.", file = sys.stderr)
-            exit(1)        
+            print("Downloaded file is corrupt. Please try again.", file=sys.stderr)
+            exit(1)
 
         exit(1)
+
 
 def check_file(filename_with_path, filename):
     # check file presence
@@ -81,24 +126,20 @@ def check_file(filename_with_path, filename):
         if check_sha256(file, filename):
             return True
 
+
 def check_sha256(file, filename):
     sha256_sum = SHA256_DICT[filename][0]
-    gz = False
-    if filename.split(".")[-1] == "gz":
-        gz = True
-    
+
     if hashlib.sha256(file.read()).hexdigest() == sha256_sum:
         return True
     else:
         return False
-        
+
+
 def calc_sha256(file):
-    gz = False
-    if file.split(".")[-1] == "gz":
-        gz = True
-    sha256 = hashlib.sha256()
     file = open(file, 'rb')
     return hashlib.sha256(file.read()).hexdigest()
+
 
 def download(filename_with_path, url):
     """
@@ -106,26 +147,27 @@ def download(filename_with_path, url):
     url = url to download
     Path with filename is returned.
     """
-    
-    download = None
+
     if sys.version_info[0] < 3:
         from urllib2 import Request, urlopen, URLError, HTTPError
     else:
         from urllib.request import Request, urlopen, URLError, HTTPError
-    
-    print("Downloading file ...", end="\r", file = sys.stderr)
+
+    print("Downloading file ...", end="\r", file=sys.stderr)
     req = Request(url)
-    print("Downloading file completed.", file = sys.stderr)        
+    print("Downloading file completed.", file=sys.stderr)
     try:
         response = urlopen(req)
         with open(filename_with_path, 'wb') as f:
             f.write(response.read())
         return filename_with_path
     except HTTPError:
-        print('HTTP Error: The server could not fulfill the request. Possibly, the file is not found on the server.', file = sys.stderr)
+        print('HTTP Error: The server could not fulfill the request.',
+              'Possibly, the file is not found on the server.', file=sys.stderr)
         exit(1)
     except URLError:
-        print ('URL Error: Server not available. Please check your internet connection.', file = sys.stderr)
+        print ('URL Error: Server not available. Please check your internet connection.',
+               file=sys.stderr)
         exit(1)
 
 if __name__ == '__main__':

--- a/pymzml/run.py
+++ b/pymzml/run.py
@@ -34,7 +34,6 @@ The class :py:class:`Writer` is still in development.
 
 from __future__ import print_function
 
-import sys
 import re
 import os
 import bisect
@@ -130,6 +129,7 @@ class Reader(object):
         self.info['referenceableParamGroupList'] = False
 
         self.info['spectrum_count'] = 0
+        self.info['chromatogram_count'] = 0
 
         self.info['obo_version'] = obo_version
 
@@ -367,6 +367,7 @@ class Reader(object):
                 positions.update(spec_positions)
                 # return positions # return only once in function leaves my brain sane :)
                 self.info['spectrum_count'] = speccnt
+                self.info['chromatogram_count'] = chromcnt
 
             else:
                 positions = None
@@ -416,9 +417,12 @@ class Reader(object):
                 self.info['referenceableParamGroupList'] = True
                 self.info['referenceableParamGroupListElement'] = element
             elif element.tag.endswith('}spectrumList'):
-                self.info['spectrum_count'] = element.attrib.get('count')
+                speccnt = element.attrib.get('count')
+                self.info['spectrum_count'] = int(speccnt) if speccnt else None
                 break
             elif element.tag.endswith('}chromatogramList'):
+                chromcnt = element.attrib.get('count')
+                self.info['chromatogram_count'] = int(chromcnt) if chromcnt else None
                 break
             else:
                 pass
@@ -575,6 +579,10 @@ class Reader(object):
 
     def getSpectrumCount(self):
         return self.info['spectrum_count']
+
+    def getChromatogramCount(self):
+        return self.info['chromatogram_count']
+
 
 class Writer(object):
     """

--- a/test/test_deconvolution.py
+++ b/test/test_deconvolution.py
@@ -25,33 +25,33 @@ import pymzml
 sys.path.append('example_scripts')
 import get_example_file
 
+
 class TestDeconvolution(unittest.TestCase):
 
     def setUp(self):
         example_file = get_example_file.open_example('deconvolution.mzML.gz')
-        run = pymzml.run.Reader(example_file, MS1_Precision = 5e-6, MSn_Precision = 20e-6)
+        run = pymzml.run.Reader(example_file, MS1_Precision=5e-6, MSn_Precision=20e-6)
         for spec in run:
             # there is only one spectrum, so just read this
             self.spec = spec
             break
-
 
     def check_peaklist(self, mz_range, result):
         tmp = self.spec.deRef()
         deconvoluted_peak_list = tmp.deconvolutedPeaks
 
         # reduce to interesting range
-        tmp_deconv_peaks = [ (mass,i) for mass, i in deconvoluted_peak_list if mz_range[0] <= mass <= mz_range[1] ]
+        tmp_deconv_peaks = [(mass, i) for mass, i in deconvoluted_peak_list
+                            if mz_range[0] <= mass <= mz_range[1]]
 
         self.assertEqual(len(tmp_deconv_peaks), len(result))
         for pos, (mass, i) in enumerate(tmp_deconv_peaks):
             self.assertAlmostEqual(mass, result[pos][0])
             self.assertAlmostEqual(i, result[pos][1])
 
-
     def check_deconvolution_with_debug_parameter(self, mz_range, expected_result):
         tmp = self.spec.deRef()
-        deconv_peaklist, masses2mz = tmp.deconvolute_peaks(debug = True)
+        deconv_peaklist, masses2mz = tmp.deconvolute_peaks(debug=True)
         result = []
         for mass, results in masses2mz.items():
             if mz_range[0] < mass < mz_range[1]:
@@ -63,38 +63,36 @@ class TestDeconvolution(unittest.TestCase):
         tmp.reduce(tuple(mz_range))
         self.assertEqual(tmp._get_deisotopedMZ_for_chargeDeconvolution(), expected_result)
 
-
-
-
     def test_masses(self):
         self.check_peaklist((1163, 1208), [(1190.5785115257675, 19276.015691004373)])
         # this is correct
         self.check_peaklist((1191, 1400), [(1208.5995290987673, 27546.527600749054)])
         self.check_peaklist((2300, 2500), [(2395.169033526201, 19792.568515412233)])
 
-
     def test_devonvolution_intensities(self):
         # belonging to mass 1190
-        self.check_devonvolution_intensities([590, 615], [(596.2956063083736, 9214.135922430825, 2, 2), (605.3046530030003, 14551.997036341349, 2, 3)])
+        self.check_devonvolution_intensities([590, 615], [
+            (596.2956063083736, 9214.135922430825, 2, 2),
+            (605.3046530030003, 14551.997036341349, 2, 3),
+        ])
         # belonging to mass 1190
-        self.check_devonvolution_intensities([1190, 1204], [(1191.5876398350977, 10061.879768573546, 1, 3), (1198.5917932298705, 19792.568515412233, 2, 4)])
-        
-
+        self.check_devonvolution_intensities([1190, 1204], [
+            (1191.5876398350977, 10061.879768573546, 1, 3),
+            (1198.5917932298705, 19792.568515412233, 2, 4),
+        ])
 
     def test_deconvolution_with_debug_parameter(self):
         expected_result = [[1208.5947530724607, [(605.3046530030003, 14551.997036341349, 2, 3)]],
-                           [1208.604305125074,  [(1209.611581591844, 12994.530564407705, 1, 3)]]]
+                           [1208.604305125074, [(1209.611581591844, 12994.530564407705, 1, 3)]]]
         self.check_deconvolution_with_debug_parameter([1208, 1210], expected_result)
 
-
-        expected_result = [[2395.169033526201,  [(1198.5917932298705, 19792.568515412233, 2, 4)]]]
+        expected_result = [[2395.169033526201, [(1198.5917932298705, 19792.568515412233, 2, 4)]]]
         self.check_deconvolution_with_debug_parameter([2390, 2400], expected_result)
 
         expected_result = [[1190.5803633683277, [(1191.5876398350977, 10061.879768573546, 1, 3)]],
                            [1190.5766596832073, [(596.2956063083736, 9214.135922430825, 2, 2)]]]
         self.check_deconvolution_with_debug_parameter([1163, 1208], expected_result)
 
-        
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_obo.py
+++ b/test/test_obo.py
@@ -1,9 +1,19 @@
 import unittest
-import os
 
 import pymzml.obo
 
+
 class TestObo(unittest.TestCase):
+
+    def test_normalize_version(self):
+        normalize = pymzml.obo.oboTranslator._oboTranslator__normalize_version
+
+        self.assertEqual(normalize(None), None)
+        self.assertEqual(normalize('1.0.0'), '1.0.0')
+        self.assertEqual(normalize('5.69.200-moop'), '5.69.200-moop')
+        self.assertEqual(normalize('2340'), '2340.0.0')
+        self.assertEqual(normalize('234.0'), '234.0.0')
+        self.assertEqual(normalize('2.3.4.0'), '2.3.4.0')
 
     def test_valid_obo(self):
         # Test features of the OBO that differ for each version

--- a/test/test_readChromMzML.py
+++ b/test/test_readChromMzML.py
@@ -20,12 +20,11 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-import subprocess as sub
 import os
-from nose.tools import nottest
 from nose.plugins.attrib import attr
 
 import pymzml
+
 
 class TestReadChromatogram(unittest.TestCase):
 
@@ -64,7 +63,7 @@ class TestReadChromatogram(unittest.TestCase):
 
         self.check_file(run)
 
-    @attr('numpress') 
+    @attr('numpress')
     def test_read_numpress(self):
         run = pymzml.run.Reader(self.mini_numpress_file)
         self.assertFalse(run.info['seekable'])
@@ -75,7 +74,7 @@ class TestReadChromatogram(unittest.TestCase):
         chrom = run[self.numpress_chrom_id]
 
         self.assertEqual(len(chrom.peaks), 176)
-        self.assertAlmostEqual(sum(chrom.i), 3657.0 )
+        self.assertAlmostEqual(sum(chrom.i), 3657.0)
 
         self.assertAlmostEqual(chrom.i[0], 0.0)
         self.assertAlmostEqual(chrom.i[-1], 28.0)

--- a/test/test_readChromMzML.py
+++ b/test/test_readChromMzML.py
@@ -40,8 +40,14 @@ class TestReadChromatogram(unittest.TestCase):
     def check_file(self, run):
         all_chromatograms = list(run)
         self.assertEqual(len(all_chromatograms), 3)
+        self.assertEqual(run.getChromatogramCount(), len(all_chromatograms))
+        self.assertEqual(run.getSpectrumCount(), 0)
 
         chrom = run[self.chromatogram_id]
+
+        # Chromatogram/spectrum counts should not change by random access
+        self.assertEqual(run.getChromatogramCount(), len(all_chromatograms))
+        self.assertEqual(run.getSpectrumCount(), 0)
 
         self.assertEqual(len(chrom.peaks), 176)
         self.assertAlmostEqual(sum(chrom.i), 13374.0)


### PR DESCRIPTION
When parsing mzML files with spectra or chromatograms in them, it's useful to know how many spectra or chromatograms are included in the file.

The existing code already counted spectra but did not count chromatograms. The following pull requests adds this functionality, modeled closely on the logic around `spectrum_count`. As a bonus, I have also added unit tests, fixed bugs/breaks in existing uint tests, made a few more files conform to PEP8, and broken up a variety of large, monolithic functions into smaller, more reusable components.

If this request is accepted, it probably merits a bump to `v0.7.7`.