### PR TITLE
Removed from all the class-defining .py files the shebang line that i…

### DIFF
--- a/pymzml/obo.py
+++ b/pymzml/obo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3.2
 # -*- coding: utf-8 -*-
 # encoding: utf-8
 """

--- a/pymzml/plot.py
+++ b/pymzml/plot.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3.2
 # -*- coding: utf-8 -*-
 # encoding: utf-8
 """

--- a/pymzml/run.py
+++ b/pymzml/run.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3.4
 # -*- coding: utf-8 -*-
 # encoding: utf-8
 """

--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3.2
 # -*- coding: utf-8 -*-
 # encoding: utf-8
 """


### PR DESCRIPTION
…s not required and makes packaging the software for both Python2 and Python3 more complex.