### PR TITLE
Add support for generating python wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import os, requests, platform
-from distutils.core import setup
+from setuptools import setup
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
 # from pymzml.version import pymzml_version


### PR DESCRIPTION
- this enables `setup.py bdist_wheel`, which eases pypi upload