### PR TITLE
modified scan_time to report retention time and its unit

### DIFF
--- a/example_scripts/extract_ion_chromatogram.py
+++ b/example_scripts/extract_ion_chromatogram.py
@@ -41,7 +41,7 @@ def main():
                 for mz,I in has_peak_matches:
                     time_dependent_intensities.append(
                         [
-                            spectrum.scan_time,
+                            spectrum.scan_time_in_minutes(),
                             I,
                             mz
                         ]

--- a/example_scripts/get_precursors.py
+++ b/example_scripts/get_precursors.py
@@ -30,7 +30,9 @@ def main():
         if spectrum.ms_level == 2:
             selected_precursors = spectrum.selected_precursors
             if spectrum.selected_precursors is not None:
-                for precursor_mz, precursor_intensity in selected_precursors:
+                for precursor_dict in selected_precursors:
+                    precursor_mz = precursor_dict['mz']
+                    precursor_i = precursor_dict['i']
                     rounded_precursor_mz = round(precursor_mz,3)
                     if rounded_precursor_mz not in fragmented_precursors.keys():
                         fragmented_precursors[rounded_precursor_mz] = []

--- a/example_scripts/simple_parser.py
+++ b/example_scripts/simple_parser.py
@@ -26,7 +26,7 @@ def main(mzml_file):
             'Spectrum {0}, MS level {ms_level} @ RT {scan_time:1.2f}'.format(
                 spec.ID,
                 ms_level = spec.ms_level,
-                scan_time = spec.scan_time
+                scan_time = spec.scan_time_in_minutes()
             )
         )
     print(

--- a/pymzml/plot.py
+++ b/pymzml/plot.py
@@ -383,13 +383,13 @@ class Factory(object):
             x_max = max(x_vals)
             x_min = min(x_vals)
 
-            if self.x_max[plot_num] > x_max:
+            if self.x_max[plot_num] == float('Inf') or self.x_max[plot_num] < x_max:
                 self.x_max[plot_num] = x_max
-            if self.x_min[plot_num] < x_min:
+            if self.x_min[plot_num] == -float('Inf') or self.x_min[plot_num] > x_min:
                 self.x_min[plot_num] = x_min
-            if self.y_max[plot_num] > y_max:
+            if self.y_max[plot_num] == float('Inf') or self.y_max[plot_num] < y_max:
                 self.y_max[plot_num] = y_max
-            if self.y_min[plot_num] < y_min:
+            if self.y_min[plot_num] == -float('Inf') or self.y_min[plot_num] > y_min:
                 self.y_min[plot_num] = y_min
 
             if style[0] == 'sticks':

--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -457,6 +457,7 @@ class Spectrum(MS_Spectrum):
         self._profile                      = None
         self._reprofiled_peaks             = None
         self._scan_time                    = None
+        self._scan_time_unit               = None
         self._t_mass_set                   = None
         self._t_mz_set                     = None
         self._TIC                          = None
@@ -855,25 +856,47 @@ class Spectrum(MS_Spectrum):
     @property
     def scan_time(self):
         """
-        Property to access the retention time in minutes.
+        Property to access the retention time and retention time unit.
+        Please note, that we do not assume the retention time unit,
+        if it is not correctly defined in the mzML. 
+        It is set to 'unicorns' in this case.
 
         Returns:
             scan_time (float):
+            scan_time_unit (str):
         """
-        if self._scan_time is None:
+        if self._scan_time is None or self._scan_time_unit is None:
             scan_time_ele = self.element.find(
                 ".//*[@accession='MS:1000016']".format(
                     ns=self.ns
                 )
             )
             self._scan_time = float(scan_time_ele.attrib.get('value'))
-            time_unit = scan_time_ele.get('unitName')
-            if time_unit.lower() == 'second':
-                self._scan_time /= 60.0
-            elif time_unit.lower() == 'minute':
-                pass
-            else:
-                raise Exception("Time unit '{0}' unknown".format(time_unit))
+            self._scan_time_unit = scan_time_ele.get('unitName', 'unicorns')
+        return self._scan_time, self._scan_time_unit
+
+    # @property
+    def scan_time_in_minutes(self):
+        """
+        Property to access the retention time in minutes.
+        If the retention time unit is defined within the mzML,
+        the retention time is converted into minutes and returned 
+        without the unit.
+
+        Returns:
+            scan_time (float):
+        """
+
+        self._scan_time, time_unit = self.scan_time
+        if self._scan_time_unit.lower() == 'second':
+            self._scan_time /= 60.0
+        elif self._scan_time_unit.lower() == 'minute':
+            pass
+        elif self._scan_time_unit.lower() == 'hour':
+            self._scan_time *= 60.0
+            pass
+        else:
+            raise Exception("Time unit '{0}' unknown".format(self._scan_time_unit))
         return self._scan_time
 
     @property

--- a/tests/main_spec_test.py
+++ b/tests/main_spec_test.py
@@ -408,7 +408,7 @@ class SpectrumTest(unittest.TestCase):
         self.assertEqual(tic, 9.6721256e07)
 
     def test_scan_time(self):
-        scan_time = self.spec.scan_time
+        scan_time, unit = self.spec.scan_time
         self.assertIsNotNone(scan_time)
         self.assertIsInstance(scan_time, float)
         self.assertEqual(scan_time, 0.023756566)

--- a/tests/ms2_spec_test.py
+++ b/tests/ms2_spec_test.py
@@ -29,7 +29,7 @@ class SpectrumMS2Test(unittest.TestCase):
 
 
     def test_scan_time(self):
-        scan_time = self.spec.scan_time
+        scan_time = self.spec.scan_time_in_minutes()
         self.assertIsNotNone(scan_time)
         self.assertIsInstance(scan_time, float)
         self.assertEqual(round(scan_time, 4), round(28.96722412109367, 4))


### PR DESCRIPTION
So far, spec.scan_time reports the retention time in minutes, performing an internal conversion into minutes, depending on the unit defined in the mzML. This fails at the moment if the unit is not minute or second.

The function has been modified to report the retention time and its unit (as defined in the mzML).
In order to keep the possibility to get the retention time in minutes, the function spec.retention_time_in_minutes() has been created, using the same conversion as before.

The tests and example scripts have been changed accordingly.

Besides this, setting xmax and ymax in plot.py has been corrected.