### PR TITLE
added 0 key for UV spectra

### DIFF
--- a/pymzml/run.py
+++ b/pymzml/run.py
@@ -91,6 +91,7 @@ class Reader(object):
 
         # Parameters
         self.ms_precisions       = {
+            0 : 0.001, #arbitrary prec for UV spectra
             1 : 5e-6,
             2 : 20e-6
         }


### PR DESCRIPTION
this adds a 0 key to `run.Reader.ms_precisions` to tolerate non-MS based spectra like UV absorbance. The precision default value is currently 0.001 which seems to be fine for my usage but please let me know if that should change and I'll tweak it.  

fixes #119 