### PR TITLE
set ms3 precision when setting MSn_Precision in run

### DIFF
--- a/pymzml/run.py
+++ b/pymzml/run.py
@@ -88,6 +88,7 @@ class Reader(object):
                 MS_precisions[1] = kwargs['MS1_Precision']
             if 'MSn_Precision' in kwargs.keys():
                 MS_precisions[2] = kwargs['MSn_Precision']
+                MS_precisions[3] = kwargs['MSn_Precision']
 
         # Parameters
         self.ms_precisions       = {


### PR DESCRIPTION
Potential fix for #121 .
When setting MSn_Precision when initialising the reader, MS2 and MS3 precision are set. 