### PR TITLE
Fix #153

### DIFF
--- a/pymzml/run.py
+++ b/pymzml/run.py
@@ -367,9 +367,7 @@ class Reader(object):
                 break
             elif element.tag.endswith("}chromatogramList"):
                 chrom_cnt = element.attrib.get("count", None)
-                if chrom_cnt is None:
-                    self.info["chromatogram_count"] = None
-                else:
+                if chrom_cnt:
                     self.info["chromatogram_count"] = int(chrom_cnt)
                 break
             elif element.tag.endswith("}run"):

--- a/pymzml/run.py
+++ b/pymzml/run.py
@@ -336,6 +336,8 @@ class Reader(object):
             ElementTree.iterparse(self.info["file_object"], events=("end", "start"))
         )  # NOTE: end might be sufficient
         _, self.root = next(mzml_iter)
+        self.info["chromatogram_count"] = None
+        self.info["spectrum_count"] = None
         while True:
             event, element = next(mzml_iter, ("END", "END"))
             if element.tag.endswith("}mzML"):

--- a/tests/main_reader_test.py
+++ b/tests/main_reader_test.py
@@ -187,13 +187,17 @@ class runTest(unittest.TestCase):
 
     def test_get_spec_count(self):
         self.assertEqual(self.reader_compressed_indexed.get_spectrum_count(), 2918)
-        # self.assertEqual(self.reader_compressed_indexed.getChromatogramCount(), 1) # Failing
         self.assertEqual(self.reader_compressed_unindexed.get_spectrum_count(), 2918)
-        # self.assertEqual(self.reader_compressed_unindexed.getChromatogramCount, 1) # Failing
         self.assertEqual(self.reader_uncompressed_unindexed.get_spectrum_count(), 2918)
-        # self.assertEqual(self.reader_uncompressed_unindexed.getChromatogramCount(), 1) # Failing
         self.assertEqual(self.reader_uncompressed_unindexed.get_spectrum_count(), 2918)
-        # self.assertEqual(self.reader_uncompressed_ununindexed.getChromatogramCount(), 1) # Failing
+
+    def test_chrom_count_chrom_file(self):
+        reader = run.Reader(self.paths[3])
+        self.assertEqual(reader.get_chromatogram_count(), 3)
+
+    def test_chrom_count_spec_file(self):
+        reader = run.Reader(self.paths[0])
+        self.assertEqual(reader.get_chromatogram_count(), None)
 
     def test_readers_remeber_spawned_spectra(self):
         """


### PR DESCRIPTION
- initialize chromatogram_count with None
- initialize spectrum_count with None
- supply tests for files with only chromatograms and files with spectra
and chromtograms