### PR TITLE
Support for Django (web framework) UploadedFile - optional

### DIFF
--- a/pymzml/file_classes/standardMzml.py
+++ b/pymzml/file_classes/standardMzml.py
@@ -41,6 +41,12 @@ class StandardMzml(object):
         return open(self.path, "rb")
 
     def get_file_handler(self, encoding):
+        try:
+            from django.core.files.uploadedfile import UploadedFile
+            if isinstance(mzml_file, UploadedFile):
+                return
+        except ImportError:
+            pass
         return codecs.open(self.path, mode="r", encoding=encoding)
 
     def __getitem__(self, identifier):

--- a/pymzml/file_classes/standardMzml.py
+++ b/pymzml/file_classes/standardMzml.py
@@ -43,8 +43,8 @@ class StandardMzml(object):
     def get_file_handler(self, encoding):
         try:
             from django.core.files.uploadedfile import UploadedFile
-            if isinstance(mzml_file, UploadedFile):
-                return
+            if isinstance(self.path, UploadedFile):
+                return self.path
         except ImportError:
             pass
         return codecs.open(self.path, mode="r", encoding=encoding)

--- a/pymzml/file_interface.py
+++ b/pymzml/file_interface.py
@@ -49,6 +49,16 @@ class FileInterface(object):
             return bytesMzml.BytesMzml(
                 path_or_file, self.encoding, self.build_index_from_scratch
             )
+
+        try: 
+            from django.core.files.uploadedfile import UploadedFile
+            if isinstance(path_or_file, UploadedFile):
+                return standardMzml.StandardMzml(
+                    path_or_file, self.encoding, self.build_index_from_scratch
+                )
+        except ImportError:
+            pass 
+
         if path_or_file.endswith(".gz"):
             if self._indexed_gzip(path_or_file):
                 return indexedGzip.IndexedGzip(path_or_file, self.encoding)


### PR DESCRIPTION
It's a hack - but not a monkey-patch, and could be of use. I'd like to work with you to make it appropriate for inclusion to minimize our burden of maintaining this separate repo. 

I've bracketed it in try/except clauses so that it doesn't require Django (and shouldn't break tests) - but otherwise handles uploaded files directly. 

Django's UploadedFile is a base class that handles temporary files (which might not be re-openable) and InMemoryUploadedFiles (which don't even have a backing file).