### PR TITLE
Feature/np optimization peaks

### DIFF
--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -1025,8 +1025,9 @@ class Spectrum(MS_Spectrum):
                 mz = self._decode(*mz_params)
                 i = self._decode(*i_params)
                 # self._peak_dict['raw'] = np.ndarray(len(mz), dtype=tuple)
-                for pos, mz_val in enumerate(mz):
-                    self._peak_dict["raw"].append((mz_val, i[pos]))
+                self._peak_dict[peak_type] = np.stack((mz, i), axis=-1)
+                # for pos, mz_val in enumerate(mz):
+                #     self._peak_dict["raw"].append((mz_val, i[pos]))
                     # self._peak_dict['raw'][pos] = [mz, 1]
             if peak_type is "raw":
                 pass
@@ -1039,7 +1040,10 @@ class Spectrum(MS_Spectrum):
             else:
                 raise KeyError
 
-        peaks = self._array(self._peak_dict[peak_type])
+        if not isinstance(peaks, np.ndarray):
+            peaks = self._array(self._peak_dict[peak_type])
+        else:
+            peaks = self._peak_dict[peak_type]
         if peak_type is "reprofiled":
             peaks = list(self._peak_dict[peak_type].items())
             peaks.sort(key=itemgetter(0))

--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -1019,16 +1019,12 @@ class Spectrum(MS_Spectrum):
         """
         if self._peak_dict[peak_type] is None:
             if self._peak_dict["raw"] is None:
-                self._peak_dict["raw"] = []
                 mz_params = self._get_encoding_parameters("m/z array")
                 i_params = self._get_encoding_parameters("intensity array")
                 mz = self._decode(*mz_params)
                 i = self._decode(*i_params)
-                # self._peak_dict['raw'] = np.ndarray(len(mz), dtype=tuple)
-                self._peak_dict[peak_type] = np.stack((mz, i), axis=-1)
-                # for pos, mz_val in enumerate(mz):
-                #     self._peak_dict["raw"].append((mz_val, i[pos]))
-                    # self._peak_dict['raw'][pos] = [mz, 1]
+                arr = np.stack((mz, i), axis=-1)
+                self._peak_dict[peak_type] = arr
             if peak_type is "raw":
                 pass
             elif peak_type is "centroided":
@@ -1040,7 +1036,7 @@ class Spectrum(MS_Spectrum):
             else:
                 raise KeyError
 
-        if not isinstance(peaks, np.ndarray):
+        if not isinstance(self._peak_dict[peak_type], np.ndarray):
             peaks = self._array(self._peak_dict[peak_type])
         else:
             peaks = self._peak_dict[peak_type]


### PR DESCRIPTION
Small optimization for combining mz and intensities.
The old method is from the time were we supported both python lists and numpy arrays.

On my test file, this increased iteration of already centroided spectra by about 25%