### PR TITLE
Add 'close' function to reader class

### DIFF
--- a/pymzml/run.py
+++ b/pymzml/run.py
@@ -339,6 +339,8 @@ class Reader(object):
         """
         return self.info['chromatogram_count']
 
+    def close(self):
+        self.info['file_object'].close()
 
 if __name__ == '__main__':
     print(__doc__)


### PR DESCRIPTION
This makes it easier to close the file_object handle https://github.com/pymzml/pymzML/blob/7f01356d409b77c809eb751431064ff5c5ba64bc/pymzml/run.py#L114 and avoids ```ResourceWarning:unclosed file``` errors when you loop through a list of mzml files or when you 'reload' the reader object. 