### PR TITLE
Implement with context for pymzml.run.Reader

### DIFF
--- a/pymzml/run.py
+++ b/pymzml/run.py
@@ -188,6 +188,12 @@ class Reader(object):
             spectrum.measured_precision = self.ms_precisions[spectrum.ms_level]
         return spectrum
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
     @property
     def file_class(self):
         """Return file object in use."""

--- a/tests/main_reader_test.py
+++ b/tests/main_reader_test.py
@@ -41,6 +41,11 @@ class runTest(unittest.TestCase):
         )
         self.reader_set_no_obo_version = run.Reader(file_no_obo_version)
 
+    def test_with_context(self):
+        with run.Reader(self.paths[0]) as reader:
+            reader[2]
+
+
     def test_determine_file_encoding(self):
         """
         """


### PR DESCRIPTION
the Reader class can now be used as the following:

```
with pymzml.run.Reader(file) as mzml_reader:
    for spec in mzml_reader:
         # do your processing
```

this ensures that the underlying file handlers are properly closed