### PR TITLE
Improve accession of cvParams in spec

### DIFF
--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -626,12 +626,14 @@ class Spectrum(MS_Spectrum):
             return_val = self.ID
         else:
             if not accession.startswith("MS:"):
-                accession = self.calling_instance.OT[accession]["id"]
+                try:
+                    accession = self.calling_instance.OT[accession]["id"]
+                except TypeError:
+                    accession = '---'
             search_string = './/*[@accession="{0}"]'.format(accession)
-
             elements = []
             for x in self.element.iterfind(search_string):
-                val = x.attrib.get("value")
+                val = x.attrib.get("value", "")
                 try:
                     val = float(val)
                 except:
@@ -644,6 +646,8 @@ class Spectrum(MS_Spectrum):
                 return_val = elements[0]
             else:
                 return_val = elements
+        if return_val == '':
+            return_val = True
         return return_val
 
     def get(self, acc, default=None):

--- a/tests/ms2_spec_test.py
+++ b/tests/ms2_spec_test.py
@@ -48,6 +48,12 @@ class SpectrumMS2Test(unittest.TestCase):
             selected_precursor, [{"mz": 443.711242675781, "i": 0.0, "charge": 2}]
         )
 
+    def test_ion_mode(self):
+        assert self.spec['positive scan'] is True
+
+    def test_ion_mode_non_existent(self):
+        assert self.spec['negative scan'] is None
+
     @unittest.skipIf(pymzml.spec.DECON_DEP is False, "ms_deisotope was not installed")
     def test_deconvolute_peaks(self):
         charge = 3


### PR DESCRIPTION
- when accessing cvParams in the spectrum class, return True if cvParam exists and does not have a value assigned
- as before, None if returned if not result for the given query could be found