### PR TITLE
Restructure precursor information

### DIFF
--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -956,7 +956,6 @@ class Spectrum(MS_Spectrum):
                 charges.append(int(c))
             for prec in precursors:
                 spec_ref = prec.get("spectrumRef")
-                print(spec_ref)
                 if spec_ref is not None:
                     ids.append(
                         regex_patterns.SPECTRUM_ID_PATTERN.search(spec_ref).group(1)

--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -160,25 +160,25 @@ class MS_Spectrum(object):
         else:
             raise Exception("Unknown data Type ({0})".format(d_type))
 
-    @property
-    def precursors(self):
-        """
-        List the precursor information of this spectrum, if available.
-
-        Returns:
-            precursor(list): list of precursor ids for this spectrum.
-        """
-        if self._precursors is None:
-            precursors = self.element.findall(
-                "./{ns}precursorList/{ns}precursor".format(ns=self.ns)
-            )
-            self._precursors = []
-            for prec in precursors:
-                spec_ref = prec.get("spectrumRef")
-                self._precursors.append(
-                    regex_patterns.SPECTRUM_ID_PATTERN.search(spec_ref).group(1)
-                )
-        return self._precursors
+    # @property
+    # def precursors(self):
+    #     """
+    #     List the precursor information of this spectrum, if available.
+    #
+    #     Returns:
+    #         precursor(list): list of precursor ids for this spectrum.
+    #     """
+    #     if self._precursors is None:
+    #         precursors = self.element.findall(
+    #             "./{ns}precursorList/{ns}precursor".format(ns=self.ns)
+    #         )
+    #         self._precursors = []
+    #         for prec in precursors:
+    #             spec_ref = prec.get("spectrumRef")
+    #             self._precursors.append(
+    #                 regex_patterns.SPECTRUM_ID_PATTERN.search(spec_ref).group(1)
+    #             )
+    #     return self._precursors
 
     def _get_encoding_parameters(self, array_type):
         """
@@ -438,6 +438,7 @@ class Spectrum(MS_Spectrum):
             "deconvoluted": None,
         }
         self._selected_precursors = None
+        self._precursors = None
         self._profile = None
         self.reprofiled = False
         self._reprofiled_peaks = None
@@ -936,10 +937,14 @@ class Spectrum(MS_Spectrum):
             selected_precursor_cs = self.element.findall(
                 ".//*[@accession='MS:1000041']"
             )
+            precursors = self.element.findall(
+                "./{ns}precursorList/{ns}precursor".format(ns=self.ns)
+            )
 
             mz_values = []
             i_values = []
             charges = []
+            ids = []
             for obj in selected_precursor_mzs:
                 mz = obj.get("value")
                 mz_values.append(float(mz))
@@ -949,10 +954,20 @@ class Spectrum(MS_Spectrum):
             for obj in selected_precursor_cs:
                 c = obj.get("value")
                 charges.append(int(c))
+            for prec in precursors:
+                spec_ref = prec.get("spectrumRef")
+                print(spec_ref)
+                if spec_ref is not None:
+                    ids.append(
+                        regex_patterns.SPECTRUM_ID_PATTERN.search(spec_ref).group(1)
+                    )
+                else:
+                    ids.append(None)
+                # ids.append()
             self._selected_precursors = []
             for pos, mz in enumerate(mz_values):
                 dict_2_save = {"mz": mz}
-                for key, list_of_values in [("i", i_values), ("charge", charges)]:
+                for key, list_of_values in [("i", i_values), ("charge", charges), ('precursor id', ids)]:
                     try:
                         dict_2_save[key] = list_of_values[pos]
                     except:

--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -160,26 +160,6 @@ class MS_Spectrum(object):
         else:
             raise Exception("Unknown data Type ({0})".format(d_type))
 
-    # @property
-    # def precursors(self):
-    #     """
-    #     List the precursor information of this spectrum, if available.
-    #
-    #     Returns:
-    #         precursor(list): list of precursor ids for this spectrum.
-    #     """
-    #     if self._precursors is None:
-    #         precursors = self.element.findall(
-    #             "./{ns}precursorList/{ns}precursor".format(ns=self.ns)
-    #         )
-    #         self._precursors = []
-    #         for prec in precursors:
-    #             spec_ref = prec.get("spectrumRef")
-    #             self._precursors.append(
-    #                 regex_patterns.SPECTRUM_ID_PATTERN.search(spec_ref).group(1)
-    #             )
-    #     return self._precursors
-
     def _get_encoding_parameters(self, array_type):
         """
         Find the correct parameter for decoding and return them as tuple.
@@ -409,7 +389,6 @@ class Spectrum(MS_Spectrum):
             "_index",
             "_measured_precision",
             "_peaks",
-            "_precursors",
             "_profile",
             "_reprofiled_peaks",
             "_t_mass_set",
@@ -438,7 +417,6 @@ class Spectrum(MS_Spectrum):
             "deconvoluted": None,
         }
         self._selected_precursors = None
-        self._precursors = None
         self._profile = None
         self.reprofiled = False
         self._reprofiled_peaks = None

--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -952,6 +952,26 @@ class Spectrum(MS_Spectrum):
                 self._selected_precursors.append(dict_2_save)
 
         return self._selected_precursors
+    
+    @property
+    def precursors(self):
+        """
+        List the precursor information of this spectrum, if available.
+        Returns:
+            precursor(list): list of precursor ids for this spectrum.
+        """
+        self.deprecation_warning(sys._getframe().f_code.co_name)
+        if self._precursors is None:
+            precursors = self.element.findall(
+                "./{ns}precursorList/{ns}precursor".format(ns=self.ns)
+            )
+            self._precursors = []
+            for prec in precursors:
+                spec_ref = prec.get("spectrumRef")
+                self._precursors.append(
+                    regex_patterns.SPECTRUM_ID_PATTERN.search(spec_ref).group(1)
+                )
+        return self._precursors
 
     def remove_precursor_peak(self):
         peaks = self.peaks("centroided")
@@ -1619,6 +1639,7 @@ class Spectrum(MS_Spectrum):
             "removeNoise": "remove_noise",
             "newPlot": "new_plot",
             "centroidedPeaks": "peaks",
+            "precursors": "selected_precursors",
         }
         warnings.warn(
             """

--- a/tests/ms2_spec_test.py
+++ b/tests/ms2_spec_test.py
@@ -47,7 +47,7 @@ class SpectrumMS2Test(unittest.TestCase):
         self.assertIsInstance(selected_precursor[0]["i"], float)
         self.assertIsInstance(selected_precursor[0]["charge"], int)
         self.assertEqual(
-            selected_precursor, [{"mz": 443.711242675781, "i": 0.0, "charge": 2}]
+            selected_precursor, [{"mz": 443.711242675781, "i": 0.0, "charge": 2, 'precursor id': None}]
         )
 
     def test_ion_mode(self):


### PR DESCRIPTION
- add precursor id to `selected_precursor` property output and remove `precursor` property
- adapt unittest for new output
- makes #255 redundant
- fixes #254 