### PR TITLE
fixing precursors property

### DIFF
--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -959,7 +959,7 @@ class Spectrum(MS_Spectrum):
             precursor(list): list of precursor ids for this spectrum.
         """
         self.deprecation_warning(sys._getframe().f_code.co_name)
-        if self._precursors is None:
+        if not hasattr(self, '_precursors'):
             precursors = self.element.findall(
                 "./{ns}precursorList/{ns}precursor".format(ns=self.ns)
             )


### PR DESCRIPTION
otherwise error:
```
site-packages/pymzml/spec.py in precursors(self)
    169             precursor(list): list of precursor ids for this spectrum.
    170         """
--> 171         if self._precursors is None:
    172             precursors = self.element.findall(
    173                 "./{ns}precursorList/{ns}precursor".format(ns=self.ns)

AttributeError: 'Spectrum' object has no attribute '_precursors'
```