### PR TITLE
Add MS precision for MS level 3

### DIFF
--- a/pymzml/run.py
+++ b/pymzml/run.py
@@ -105,6 +105,7 @@ class Reader(object):
             0: 0.0001,
             1: 5e-6,
             2: 20e-6,
+            3: 20e-6,
         }
         self.ms_precisions.update(MS_precisions)
 


### PR DESCRIPTION
- add 20e-6 as standarard precision for ms3
- fixes #283 