### PR TITLE
Adding support for millisecond retention time unit

### DIFF
--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -883,6 +883,8 @@ class Spectrum(MS_Spectrum):
         """
         if self._scan_time_in_minutes is None:
             self._scan_time, time_unit = self.scan_time
+            if self._scan_time_unit.lower() == "millisecond":
+                self._scan_time_in_minutes = self._scan_time / 1000.0 / 50.0
             if self._scan_time_unit.lower() == "second":
                 self._scan_time_in_minutes = self._scan_time / 60.0
             elif self._scan_time_unit.lower() == "minute":


### PR DESCRIPTION
It is valid to have millisecond for retention time units as shizmadzu instruments report this. Small code update to allow for this. 

```
<scanList count="1">
  <scan>
    <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="1583100" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
  </scan>
</scanList>
```