### PR TITLE
Refactor spec spectrum

### DIFF
--- a/pymzml/obo.py
+++ b/pymzml/obo.py
@@ -96,6 +96,8 @@ class OboTranslator(object):
         version (str): obo version
     """
 
+    _obo_instance_cache = {}
+
     def __init__(self, version=None):
         self.version = self.__normalize_version(version)
         self.all_dicts = []
@@ -107,6 +109,15 @@ class OboTranslator(object):
 
         # Only parse the OBO when necessary, not upon object construction
         self.__obo_parsed = False
+
+    @classmethod
+    def from_cache(cls, version):
+        version = cls.__normalize_version(version)
+        try:
+            return cls._obo_instance_cache[version]
+        except KeyError:
+            inst = cls._obo_instance_cache[version] = cls(version)
+            return inst
 
     def __setitem__(self, key, value):
         raise TypeError("OBO translator dictionaries only support assignment via .add")

--- a/pymzml/run.py
+++ b/pymzml/run.py
@@ -271,7 +271,6 @@ class Reader(object):
 
     @staticmethod
     def _obo_version_validator(version):
-
         """
         The obo version should fit file names in the obo folder.
         However, some software generate mzML with built in obo version string like:

--- a/pymzml/run.py
+++ b/pymzml/run.py
@@ -155,24 +155,22 @@ class Reader(object):
             event, element = next(self.iter, ("END", "END"))
             if event == "end":
                 if element.tag.endswith("}spectrum"):
-                    spectrum = spec.Spectrum(element)
+                    spectrum = spec.Spectrum(element, obo_version=self.OT.version)
                     if has_ref_group:
                         spectrum._set_params_from_reference_group(
                             self.info["referenceable_param_group_list_element"]
                         )
                     ms_level = spectrum.ms_level
                     spectrum.measured_precision = self.ms_precisions[ms_level]
-                    spectrum.calling_instance = self
                     return spectrum
                 if element.tag.endswith("}chromatogram"):
                     if self.skip_chromatogram:
                         continue
-                    spectrum = spec.Chromatogram(element)
+                    spectrum = spec.Chromatogram(element, obo_version=self.OT.version)
                     # if has_ref_group:
                     #     spectrum._set_params_from_reference_group(
                     #         self.info['referenceable_param_group_list_element']
                     #     )
-                    spectrum.calling_instance = self
                     return spectrum
             elif event == "END":
                 # reinit iter
@@ -201,7 +199,7 @@ class Reader(object):
         except:
             pass
         spectrum = self.info["file_object"][identifier]
-        spectrum.calling_instance = self
+        spectrum.obo_translator = self.OT
         if isinstance(spectrum, spec.Spectrum):
             spectrum.measured_precision = self.ms_precisions[spectrum.ms_level]
         return spectrum
@@ -347,7 +345,7 @@ class Reader(object):
         # required) ...
         if self.info.get("obo_version", None) is None:
             self.info["obo_version"] = "1.1.0"
-        obo_translator = obo.OboTranslator(version=self.info["obo_version"])
+        obo_translator = obo.OboTranslator.from_cache(version=self.info["obo_version"])
 
         return obo_translator
 

--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -74,22 +74,6 @@ class MS_Spectrum(object):
     General spectrum class for data handling.
     """
 
-    # __slots__ = [
-    #     # '_read_accessions',
-    #     # 'get_element_by_name',
-    #     # 'get_element_by_path',
-    #     # '_register',
-    #     # 'precursors',
-    #     # '_get_encoding_parameters',
-    #     # 'measured_precision',
-    #     # '_decode_to_numpy',
-    #     # '_median',
-    #     # 'to_string',
-    # ]
-    def __init__(self):
-        """."""
-        pass
-
     def _read_accessions(self):
         """Set all required variables for this spectrum."""
         self.accessions = {}
@@ -174,8 +158,6 @@ class MS_Spectrum(object):
             d_array_length (str) : length of the data array
         """
         numpress_encoding = False
-
-        # array_type_accession = self.calling_instance.OT[array_type]["id"]
 
         b_data_string = "./{ns}binaryDataArrayList/{ns}binaryDataArray/{ns}cvParam[@name='{name}']/..".format(
             ns=self.ns, name=array_type
@@ -427,29 +409,6 @@ class Spectrum(MS_Spectrum):
     """
 
     def __init__(self, element=ElementTree.Element(""), measured_precision=5e-6):
-
-        __slots__ = [
-            "_centroided_peaks",
-            "_centroided_peaks_sorted_by_i",
-            "_deconvoluted_peaks",
-            "_extreme_values",
-            "_i",
-            "_ID",
-            "_id_dict",
-            "_index",
-            "_measured_precision",
-            "_peaks",
-            "_profile",
-            "_reprofiled_peaks",
-            "_t_mass_set",
-            "_t_mz_set",
-            "_time",
-            "_transformed_mass_with_error",
-            "_transformed_mz_with_error",
-            "_transformed_peaks" "calling_instance" "element",
-            "internal_precision" "noise_level_estimate",
-            "selected_precursors",
-        ]
 
         self._centroided_peaks = None
         self._centroided_peaks_sorted_by_i = None
@@ -1332,17 +1291,6 @@ class Spectrum(MS_Spectrum):
         self.set_peaks(None, "centroided")
         return tmp
 
-    def _register(self, decoded_tuple):
-        d_type, array = decoded_tuple
-        if d_type == "mz":
-            self._mz = array
-        elif d_type == "i":
-            self._i = array
-        elif d_type == "time":
-            self._time = array
-        else:
-            raise Exception("Unknown data Type ({0})".format(d_type))
-
     def _mz_2_mass(self, mz, charge):
         """
         Calculate the uncharged mass for a given mz value
@@ -1775,29 +1723,6 @@ class Chromatogram(MS_Spectrum):
             measured_precision (float): in ppm, i.e. 5e-6 equals to 5 ppm.
             param (dict): parameter mapping for this spectrum
         """
-
-        __slots__ = [
-            "_measured_precision",
-            "element",
-            "noise_level_estimate",
-            "_time",
-            "_i",
-            "_t_mass_set",
-            "_peaks",
-            "_t_mz_set",
-            "_centroided_peaks",
-            "_reprofiled_peaks",
-            "_deconvoluted_peaks",
-            "_profile",
-            "_extreme_values",
-            "_centroided_peaks_sorted_by_i",
-            "_transformed_mz_with_error",
-            "_transformed_mass_with_error",
-            "_precursors",
-            "_ID",
-            "internal_precision",
-        ]
-
         self._measured_precision = measured_precision
         self.element = element
         self.noise_level_estimate = {}

--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -410,7 +410,7 @@ class Spectrum(MS_Spectrum):
         measured_precision=5e-6,
         *,
         obo_version=None,
-      ):
+    ):
         __slots__ = [
             "_centroided_peaks",
             "_centroided_peaks_sorted_by_i",

--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -403,7 +403,6 @@ class Spectrum(MS_Spectrum):
         measured_precision (float): in ppm, i.e. 5e-6 equals to 5 ppm.
 
     """
-
     def __init__(
         self, 
         element=ElementTree.Element(""), 

--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -205,9 +205,7 @@ class MS_Spectrum(object):
                             d_type = b_data_array.find(
                                 float_type_string.format(
                                     ns=self.ns,
-                                    Acc=self.obo_translator["32-bit integer"][
-                                        "id"
-                                    ],
+                                    Acc=self.obo_translator["32-bit integer"]["id"],
                                 )
                             ).get("name")
                         except:
@@ -216,9 +214,7 @@ class MS_Spectrum(object):
                                 d_type = b_data_array.find(
                                     float_type_string.format(
                                         ns=self.ns,
-                                        Acc=self.obo_translator["64-bit integer"][
-                                            "id"
-                                        ],
+                                        Acc=self.obo_translator["64-bit integer"]["id"],
                                     )
                                 ).get("name")
                             except:
@@ -285,7 +281,6 @@ class MS_Spectrum(object):
                 or "MS-Numpress linear prediction compression" in comp
                 or "MS-Numpress short logged float compression" in comp
             ):
-
                 out_data = self._decodeNumpress_to_array(out_data, comp)
             if data_type == "32-bit float":
                 # one character code may be sufficient too (f)
@@ -1213,9 +1208,7 @@ class Spectrum(MS_Spectrum):
         try:
             profile_ot = self.obo_translator.name.get("profile spectrum", None)
             if profile_ot is None:
-                profile_ot = self.obo_translator.name.get(
-                    "profile mass spectrum", None
-                )
+                profile_ot = self.obo_translator.name.get("profile mass spectrum", None)
             acc = profile_ot["id"]
             is_profile = (
                 True

--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -403,9 +403,10 @@ class Spectrum(MS_Spectrum):
         measured_precision (float): in ppm, i.e. 5e-6 equals to 5 ppm.
 
     """
+
     def __init__(
-        self, 
-        element=ElementTree.Element(""), 
+        self,
+        element=ElementTree.Element(""),
         measured_precision=5e-6,
         *,
         obo_version=None,


### PR DESCRIPTION
This PR addresses the issue described in #333.

- provides a caching mechanism based on obo version for OboTranslator
- allows Spectrum and Chromatogram to be instantiated with a obo_version as kwarg

Closes #333 