### PR TITLE
Use `elem is not None` syntax for checking truth of xml elements.

### DIFF
--- a/pymzml/msdata.py
+++ b/pymzml/msdata.py
@@ -139,7 +139,7 @@ class MsData(object):
         float_type_string = "./{ns}cvParam[@accession='{Acc}']"
 
         b_data_array = self.element.find(b_data_string)
-        if not b_data_array:
+        if b_data_array is None:
             # non-standard data array
             b_data_string = "./{ns}binaryDataArrayList/{ns}binaryDataArray/{ns}cvParam[@value='{value}']/..".format(
                 ns=self.ns, value=array_type
@@ -147,7 +147,7 @@ class MsData(object):
             b_data_array = self.element.find(b_data_string)
 
         comp = []
-        if b_data_array:
+        if b_data_array is not None:
             for cvParam in b_data_array.iterfind("./{ns}cvParam".format(ns=self.ns)):
                 if "compression" in cvParam.get("name"):
                     if "numpress" in cvParam.get("name").lower():

--- a/pymzml/spec.py
+++ b/pymzml/spec.py
@@ -474,7 +474,7 @@ class Spectrum(MsData):
         self.noise_level_estimate = {}
 
         self.ns = ""
-        if self.element:
+        if self.element is not None:
             self.ns = (
                 re.match(r"\{.*\}", element.tag).group(0)
                 if re.match(r"\{.*\}", element.tag)
@@ -489,7 +489,7 @@ class Spectrum(MsData):
         """
         Clear self.element to limit RAM usage
         """
-        if self.element:
+        if self.element is not None:
             self.element.clear()
 
     def __add__(self, other_spec):


### PR DESCRIPTION
The old way is now deprecated. 

https://docs.python.org/3/deprecations/index.html#pending-removal-in-future-versions